### PR TITLE
fix: updated REWARD_RATIO

### DIFF
--- a/src/config/shiden/crowdloan.ts
+++ b/src/config/shiden/crowdloan.ts
@@ -4,6 +4,6 @@
 export const CROWDLOAN_ENDPOINT = 'wss://kusama-rpc.polkadot.io';
 export const PARA_ID = 2120; // in kusama
 export const MINIMUM_STAKING_AMOUNT = 1;
-export const REWARD_RATIO = 24.4;
+export const REWARD_RATIO = 23.3;
 export const MIN_BALANCE = 0.01;
 export const UNIT = 12; // kusama unit


### PR DESCRIPTION
* Updated minimum rewards from 24.4SDN to 23.3SDN
  * ref: https://medium.com/astar-network/announcing-the-second-official-shiden-crowdloan-d11d71debd52 

<img width="747" alt="image" src="https://user-images.githubusercontent.com/92044428/165460511-806bb237-f07a-4c3a-bc2d-d1647d154704.png">
